### PR TITLE
No scale down on scaling activity

### DIFF
--- a/deploy/cloudformation.yaml
+++ b/deploy/cloudformation.yaml
@@ -27,6 +27,7 @@ Resources:
           - {Action: 'ec2:Describe*', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DescribeAutoScalingGroups', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DescribeAutoScalingInstances', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DescribeScalingActivities', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:SetDesiredCapacity', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:TerminateInstanceInAutoScalingGroup', Effect: Allow, Resource: '*'}
           Version: '2012-10-17'

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -175,6 +175,23 @@ def test_resize_auto_scaling_groups_activity_in_progress(monkeypatch):
     autoscaling.set_desired_capacity.assert_not_called()
 
 
+def test_resize_auto_scaling_groups_nodes_not_ready(monkeypatch):
+    monkeypatch.setattr('kube_aws_autoscaler.main.scaling_activity_in_progress', lambda a, b: False)
+    autoscaling = MagicMock()
+    autoscaling.describe_auto_scaling_groups.return_value = {
+        'AutoScalingGroups': [{
+            'AutoScalingGroupName': 'asg1',
+            'DesiredCapacity': 3,
+            'MinSize': 2,
+            'MaxSize': 10
+        }]
+    }
+    asg_size = {'asg1': 2}
+    ready_nodes = {'asg1': 2}
+    resize_auto_scaling_groups(autoscaling, asg_size, ready_nodes)
+    autoscaling.set_desired_capacity.assert_not_called()
+
+
 def test_activity_in_progress():
     autoscaling = MagicMock()
     autoscaling.describe_scaling_activities.return_value = {


### PR DESCRIPTION
Do not scale down if..

* ..any ASG activity is still in progress
* ..the number of ready nodes is lower than the ASG's current `DesiredCapacity` (this means that a node is probably booting and not registered in the API server yet)

Also do not compensate cordoned nodes which are currently being terminated by ASG (important to support `kube-node-drainer.service` as introduced in https://github.com/zalando-incubator/kubernetes-on-aws/pull/257).