### PR TITLE
Split instances processing into 50 items batches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test docker push
 
-IMAGE            ?= hjacobs/kube-aws-autoscaler
+IMAGE            ?= 971383676178.dkr.ecr.us-east-1.amazonaws.com/kube-aws-autoscaler
 VERSION          ?= $(shell git describe --tags --always --dirty)
 TAG              ?= $(VERSION)
 GITHEAD          = $(shell git rev-parse --short HEAD)

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+**NOTE** This is a fork of https://github.com/hjacobs/kube-aws-autoscaler and could drift from the origina.
+Please see original repo for the latest changes.
+
 =================================
 Kubernetes AWS Cluster Autoscaler
 =================================
@@ -85,6 +88,10 @@ See below for optional configuration parameters.
 Configuration
 =============
 
+The following command line options are required:
+``--asg``
+	AWS Autoscaling Group Name
+
 The following command line options are supported:
 
 ``--buffer-cpu-percentage``
@@ -101,8 +108,6 @@ The following command line options are supported:
     Extra number of pods to overprovision for, defaults to 10.
 ``--buffer-spare-nodes``
     Number of extra "spare" nodes to provision per ASG/AZ, defaults to 1.
-``--include-master-nodes``
-    Do not ignore auto scaling group with master nodes.
 ``--interval``
     Time to sleep between runs in seconds, defaults to 60 seconds.
 ``--once``

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -3,8 +3,9 @@ kind: Deployment
 metadata:
   labels:
     application: kube-aws-autoscaler
-    version: v0.0.1
+    version: v0.7.1
   name: kube-aws-autoscaler
+  namespace: kube-system
 spec:
   replicas: 1
   selector:
@@ -14,14 +15,25 @@ spec:
     metadata:
       labels:
         application: kube-aws-autoscaler
-        version: v0.0.1
-      annotations:
-        # FIXME: using hardcoded IAM role
-        iam.amazonaws.com/role: kube-1-app-autoscaler
+        version: 0.0.1
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/role
+                operator: In
+                values:
+                - master
+      tolerations:
+      - key: dedicated
+        operator: Equal
+        value: master
+        effect: NoSchedule
       containers:
       - name: autoscaler
-        image: hjacobs/kube-aws-autoscaler
+        image: 971383676178.dkr.ecr.us-east-1.amazonaws.com/kube-aws-autoscaler:[tag]
         imagePullPolicy: Always
         resources:
           limits:
@@ -30,3 +42,6 @@ spec:
           requests:
             cpu: 50m
             memory: 50Mi
+        args:
+        - "--asg"
+        - "asg group name"

--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -80,7 +80,7 @@ def is_node_ready(node):
     return False
 
 
-def get_nodes(api, include_master_nodes: bool=False) -> dict:
+def get_nodes(api) -> dict:
     nodes = {}
     for node in pykube.Node.objects(api):
         region = node.labels['failure-domain.beta.kubernetes.io/region']
@@ -96,14 +96,12 @@ def get_nodes(api, include_master_nodes: bool=False) -> dict:
                'region': region, 'zone': zone, 'instance_id': instance_id, 'instance_type': instance_type,
                'allocatable': allocatable,
                'ready': is_node_ready(node),
-               'unschedulable': node.obj['spec'].get('unschedulable', False),
-               'master': node.labels.get('master', 'false') == 'true'}
-        if include_master_nodes or not obj['master']:
-            nodes[node.name] = obj
+               'unschedulable': node.obj['spec'].get('unschedulable', False)}
+        nodes[node.name] = obj
     return nodes
 
 
-def get_nodes_by_asg_zone(autoscaling, nodes: dict) -> dict:
+def get_nodes_by_asg_zone(autoscaling, nodes: dict, asg: str) -> dict:
     # first map instance_id to node object for later look up
     instances = {}
     for node in nodes.values():
@@ -111,12 +109,15 @@ def get_nodes_by_asg_zone(autoscaling, nodes: dict) -> dict:
 
     nodes_by_asg_zone = collections.defaultdict(list)
 
+    logger.info('Filtering out ASG:{}'.format(asg))
     response = autoscaling.describe_auto_scaling_instances(InstanceIds=list(instances.keys()))
     for instance in response['AutoScalingInstances']:
-        instances[instance['InstanceId']]['asg_name'] = instance['AutoScalingGroupName']
-        instances[instance['InstanceId']]['asg_lifecycle_state'] = instance['LifecycleState']
-        key = instance['AutoScalingGroupName'], instance['AvailabilityZone']
-        nodes_by_asg_zone[key].append(instances[instance['InstanceId']])
+        logger.debug('Instance: {}'.format(instance))
+        if instance['AutoScalingGroupName'] == asg:
+            instances[instance['InstanceId']]['asg_name'] = instance['AutoScalingGroupName']
+            instances[instance['InstanceId']]['asg_lifecycle_state'] = instance['LifecycleState']
+            key = instance['AutoScalingGroupName'], instance['AvailabilityZone']
+            nodes_by_asg_zone[key].append(instances[instance['InstanceId']])
     return nodes_by_asg_zone
 
 
@@ -318,14 +319,18 @@ def get_ready_nodes_by_asg(nodes_by_asg_zone):
     return ready_nodes_by_asg
 
 
-def autoscale(buffer_percentage: dict, buffer_fixed: dict, buffer_spare_nodes: int=0, include_master_nodes: bool=False, dry_run: bool=False):
+def autoscale(buffer_percentage: dict, buffer_fixed: dict, asg: str, buffer_spare_nodes: int=0, dry_run: bool=False):
     api = get_kube_api()
 
-    all_nodes = get_nodes(api, include_master_nodes)
+    all_nodes = get_nodes(api)
     region = list(all_nodes.values())[0]['region']
 
     autoscaling = boto3.client('autoscaling', region)
-    nodes_by_asg_zone = get_nodes_by_asg_zone(autoscaling, all_nodes)
+    nodes_by_asg_zone = get_nodes_by_asg_zone(autoscaling, all_nodes, asg)
+
+    if len(nodes_by_asg_zone) == 0:
+        raise ValueError('ASG: {} returned 0 nodes!'.format(asg))
+
     # we only consider nodes found in an ASG (old "ghost" nodes returned from Kubernetes API are ignored)
     nodes_by_name = get_nodes_by_name(itertools.chain(*nodes_by_asg_zone.values()))
 
@@ -342,11 +347,10 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--dry-run', help='Dry run mode: do not change anything, just print what would be done',
                         action='store_true')
+    parser.add_argument('--asg', help='AWS autoscaling group', required=True)
     parser.add_argument('--debug', '-d', help='Debug mode: print more information', action='store_true')
     parser.add_argument('--once', help='Run loop only once and exit', action='store_true')
     parser.add_argument('--interval', type=int, help='Loop interval (default: 60s)', default=60)
-    parser.add_argument('--include-master-nodes', help='Do not ignore auto scaling group with master nodes',
-                        action='store_true')
     parser.add_argument('--buffer-spare-nodes', type=int,
                         help='Number of extra "spare" nodes to provision per ASG/AZ (default: 1)', default=1)
     for resource in RESOURCES:
@@ -370,8 +374,7 @@ def main():
 
     while True:
         try:
-            autoscale(buffer_percentage, buffer_fixed, buffer_spare_nodes=args.buffer_spare_nodes,
-                      include_master_nodes=args.include_master_nodes, dry_run=args.dry_run)
+            autoscale(buffer_percentage, buffer_fixed, asg=args.asg, buffer_spare_nodes=args.buffer_spare_nodes, dry_run=args.dry_run)
         except:
             logger.exception('Failed to autoscale')
         if args.once:


### PR DESCRIPTION
### Overview:
It appears that `AWS/boto` can describe only 50 instances at the time (hard limit). For large clusters, we ran into the issue since we can easily exceed 50 node cluster

### Changes:
Split instances into 50 items batches for processing.