### PR TITLE
update supported Kubernetes versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Disclaimer
 ==========
 
 **Use at your own risk!**
-This autoscaler was only tested with Kubernetes versions 1.5.2 to 1.6.2.
+This autoscaler was only tested with Kubernetes versions 1.5.2 to 1.6.7.
 There is no guarantee that it works in previous Kubernetes versions.
 
 **Is it production ready?**


### PR DESCRIPTION
This should be correct.

Can we tag `0.10` once it's merged? :)