### PR TITLE
Tag based filtering

### DIFF
--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -139,7 +139,7 @@ def get_nodes_by_asg_zone(autoscaling, nodes: dict, include_tags: dict) -> dict:
             keep = include_tags is None
             name = asg['AutoScalingGroupName']
             for tag in asg['Tags']:
-                if tag['Key'] == 'autoscaled' and tag['Value'] == 'false':
+                if tag['Key'] == 'kube_aws_autoscale' and tag['Value'] == 'false':
                     logger.info('Not considering ASG {} due to explicitly having the autoscale=false tag'.format(name))
                     asgs.discard(name)
                     break

--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -136,15 +136,19 @@ def get_nodes_by_asg_zone(autoscaling, nodes: dict, include_tags: dict) -> dict:
         
         asgresponse = autoscaling.describe_auto_scaling_groups(AutoScalingGroupNames=list(asgs))
         for asg in asgresponse['AutoScalingGroups']:
-            if include_tags != None:
-                for key in include_tags:
-                    if not key in asg['Tags'] or asg['Tags'][key] != include_tags[key]:
-                        logger.info('Not considering ASG {} due to not having the desired tags'.format(asg))
-                        asgs.remove(asg)
-                        break
-            if 'autoscale' in asg['Tags'] and asg['Tags']['autoscale'] == 'false':
-               logger.info('Not considering ASG {} due to expliclty having the autoscale=false tag'.format(asg))
-               asgs.remove(asg)
+            keep = include_tags == None
+            name = asg['AutoScalingGroupName']
+            for tag in asg['Tags']:
+                if tag['Key'] == 'autoscaled' and tag['Value'] == 'false':
+                    logger.info('Not considering ASG {} due to explicitly having the autoscale=false tag'.format(name))
+                    asgs.discard(name)
+                    break
+                elif include_tags != None and tag['Key'] in include_tags and tag['Value'] == include_tags[tag['Key']]:
+                    keep = True
+
+            if not keep:
+                logger.info('Not considering ASG {} due to not having the desired tags'.format(name))
+                asgs.discard(name)
             
         for instance in response['AutoScalingInstances']:
             if instance['AutoScalingGroupName'] in asgs:
@@ -407,7 +411,7 @@ def autoscale(buffer_percentage: dict, buffer_fixed: dict,
         for elem in elems:
             k, v = elem.split('=')
             include_tags[k] = v
-    
+        
     api = get_kube_api()
 
     all_nodes = get_nodes(api, include_master_nodes)


### PR DESCRIPTION
Filter autoscaling groups to interact with based on tags. If the ASG is tagged autoscale=false, it will be ignored. If on the other hand the --only-tagged flag is provided, _all_ ASGs except those tagged via the key=value passed will be ignored.  

Indirectly addresses #26 