### PR TITLE
Smiller/fix scaledown up bug

### DIFF
--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -197,7 +197,7 @@ def format_resource(value: float, resource: str):
     return '{:.0f}'.format(value)
 
 
-def slow_down_downscale(autoscaling, current_desired_size: int, asg_sizes: dict, nodes_by_asg_zone: dict, scale_down_step_fixed: int, scale_down_step_percentage: float):
+def slow_down_downscale(autoscaling, asg_sizes: dict, nodes_by_asg_zone: dict, scale_down_step_fixed: int, scale_down_step_percentage: float):
     # validate scale-down-step-fixed, must be >= 1
     if scale_down_step_fixed < 1:
         raise ValueError('scale-down-step-fixed must be >= 1')
@@ -221,7 +221,7 @@ def slow_down_downscale(autoscaling, current_desired_size: int, asg_sizes: dict,
                 # percentage amount is too small, make sure we downscale by fixed amount at least
                 new_desired_size_percentage = new_desired_size_fixed
             current_desired_capacity = get_asg_desired_capacity(autoscaling, asg_name)
-            new_desired_size = min(new_desired_size_fixed, new_desired_size_percentage, current_desired_size)
+            new_desired_size = min(new_desired_size_fixed, new_desired_size_percentage, current_desired_capacity)
             logger.info('Slowing down downscale: changing desired size of ASG {} (current size is {}) from {} to {}'.format(
                         asg_name, current_size, desired_size, new_desired_size))
             asg_sizes[asg_name] = new_desired_size
@@ -402,7 +402,7 @@ def autoscale(buffer_percentage: dict, buffer_fixed: dict,
     usage_by_asg_zone = calculate_usage_by_asg_zone(pods, nodes_by_name)
     asg_size = calculate_required_auto_scaling_group_sizes(nodes_by_asg_zone, usage_by_asg_zone, buffer_percentage, buffer_fixed,
                                                            buffer_spare_nodes=buffer_spare_nodes, disable_scale_down=disable_scale_down)
-    asg_size = slow_down_downscale(autoscaling, asg_size, nodes_by_asg_zone, scale_down_step_fixed, scale_down_step_percentage, current_desired_capacity)
+    asg_size = slow_down_downscale(autoscaling, asg_size, nodes_by_asg_zone, scale_down_step_fixed, scale_down_step_percentage)
     ready_nodes_by_asg = get_ready_nodes_by_asg(nodes_by_asg_zone)
     resize_auto_scaling_groups(autoscaling, asg_size, ready_nodes_by_asg, dry_run)
 

--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -392,7 +392,7 @@ def autoscale(buffer_percentage: dict, buffer_fixed: dict,
     region = list(all_nodes.values())[0]['region']
     autoscaling = boto3.client('autoscaling', region)
     nodes_by_asg_zone = get_nodes_by_asg_zone(autoscaling, all_nodes)
-    
+
     # we only consider nodes found in an ASG (old "ghost" nodes returned from Kubernetes API are ignored)
     nodes_by_name = get_nodes_by_name(itertools.chain(*nodes_by_asg_zone.values()))
 

--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -392,7 +392,6 @@ def autoscale(buffer_percentage: dict, buffer_fixed: dict,
     region = list(all_nodes.values())[0]['region']
     autoscaling = boto3.client('autoscaling', region)
     nodes_by_asg_zone = get_nodes_by_asg_zone(autoscaling, all_nodes)
-    current_desired_capacity = get_asg_desired_capacity(autoscaling)
     
     # we only consider nodes found in an ASG (old "ghost" nodes returned from Kubernetes API are ignored)
     nodes_by_name = get_nodes_by_name(itertools.chain(*nodes_by_asg_zone.values()))


### PR DESCRIPTION
We had a case of runaway scale-up caused by the slow scale down logic.  There can be a case where there are more instances running than desired, but when the slow down logic applies, it uses the current instance count to change the desired count, to a value higher than it was currently set.  Example:

23 instances running, 20 desired, slow scale down sets desired to 22.  Two nodes then spin up (because 3 of those instances were terminating, not active).
Then you get
25 instances running, 22 desired count, slow down scale sets to 24.  etc. etc. until we had more than a hundred nodes running.

This change includes the current desired capacity to avoid this.